### PR TITLE
feat: Add DeepSeek API Support

### DIFF
--- a/JoeVoice.xcodeproj/project.pbxproj
+++ b/JoeVoice.xcodeproj/project.pbxproj
@@ -459,7 +459,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1020;
+				CURRENT_PROJECT_VERSION = 1030;
 				DEVELOPMENT_ASSET_PATHS = "\"JoeVoice/Preview Content\"";
 				DEVELOPMENT_TEAM = 56VCH6FL59;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -477,7 +477,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.joeli.JoeVoice;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
@@ -496,7 +496,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1020;
+				CURRENT_PROJECT_VERSION = 1030;
 				DEVELOPMENT_ASSET_PATHS = "\"JoeVoice/Preview Content\"";
 				DEVELOPMENT_TEAM = 56VCH6FL59;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -514,7 +514,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.joeli.JoeVoice;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";

--- a/JoeVoice/Services/AIService.swift
+++ b/JoeVoice/Services/AIService.swift
@@ -9,6 +9,7 @@ enum AIProvider: String, CaseIterable {
     case openAI = "OpenAI"
     case openRouter = "OpenRouter"
     case mistral = "Mistral"
+    case deepseek = "DeepSeek"
     case elevenLabs = "ElevenLabs"
     case deepgram = "Deepgram"
     case ollama = "Ollama"
@@ -31,6 +32,8 @@ enum AIProvider: String, CaseIterable {
             return "https://openrouter.ai/api/v1/chat/completions"
         case .mistral:
             return "https://api.mistral.ai/v1/chat/completions"
+        case .deepseek:
+            return "https://api.deepseek.com/chat/completions"
         case .elevenLabs:
             return "https://api.elevenlabs.io/v1/speech-to-text"
         case .deepgram:
@@ -56,6 +59,8 @@ enum AIProvider: String, CaseIterable {
             return "gpt-5-mini"
         case .mistral:
             return "mistral-large-latest"
+        case .deepseek:
+            return "deepseek-chat"
         case .elevenLabs:
             return "scribe_v1"
         case .deepgram:
@@ -117,6 +122,11 @@ enum AIProvider: String, CaseIterable {
                 "mistral-medium-latest",
                 "mistral-small-latest",
                 "mistral-saba-latest"
+            ]
+        case .deepseek:
+            return [
+                "deepseek-chat",
+                "deepseek-reasoner"
             ]
         case .elevenLabs:
             return ["scribe_v1", "scribe_v1_experimental"]

--- a/JoeVoice/Views/AI Models/APIKeyManagementView.swift
+++ b/JoeVoice/Views/AI Models/APIKeyManagementView.swift
@@ -393,7 +393,7 @@ struct APIKeyManagementView: View {
                             Spacer()
                             
                             HStack(spacing: 8) {
-                                Text((aiService.selectedProvider == .groq || aiService.selectedProvider == .gemini || aiService.selectedProvider == .cerebras) ? "Free" : "Paid")
+                                Text((aiService.selectedProvider == .groq || aiService.selectedProvider == .gemini || aiService.selectedProvider == .cerebras || aiService.selectedProvider == .deepseek) ? "Free" : "Paid")
                                     .font(.caption2)
                                     .foregroundColor(.secondary)
                                     .padding(.horizontal, 6)
@@ -414,6 +414,8 @@ struct APIKeyManagementView: View {
                                             URL(string: "https://console.anthropic.com/settings/keys")!
                                         case .mistral:
                                             URL(string: "https://console.mistral.ai/api-keys")!
+                                        case .deepseek:
+                                            URL(string: "https://platform.deepseek.com/api_keys")!
                                         case .elevenLabs:
                                             URL(string: "https://elevenlabs.io/speech-synthesis")!
                                         case .deepgram:


### PR DESCRIPTION
## Summary
- Add DeepSeek as a new AI provider option for enhanced transcription processing
- Integrate DeepSeek chat and reasoning models
- Update version to 1.0.3 with proper API key management

## Changes Made
- Added `deepseek` case to `AIProvider` enum with proper configuration
- Integrated DeepSeek API endpoints (`https://api.deepseek.com/chat/completions`)
- Added support for `deepseek-chat` and `deepseek-reasoner` models
- Updated API key management UI with DeepSeek provider option and API key URL
- Enhanced settings to include DeepSeek as a "Free" tier provider
- Updated app version from 1.0.2 to 1.0.3 (build 1030)

## Technical Details
- DeepSeek uses OpenAI-compatible API format, leveraging existing error handling and rate limiting
- Automatic integration with existing AI enhancement service architecture
- No additional dependencies required

## Test Plan
- [x] Project builds successfully with new DeepSeek integration
- [x] DeepSeek appears in AI provider selection dropdown
- [x] API key management UI includes DeepSeek-specific configuration
- [x] Version numbers updated correctly
- [x] Integration follows existing patterns for OpenAI-compatible providers

## Resolves
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)